### PR TITLE
✨ IMPROVE: Add support for Svelte chunks

### DIFF
--- a/syntaxes/myst.tmLanguage
+++ b/syntaxes/myst.tmLanguage
@@ -355,6 +355,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#directive-code-svelte</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#directive-code-ts</string>
           </dict>
           <dict>
@@ -2820,6 +2824,90 @@
               <dict>
                 <key>include</key>
                 <string>source.shell</string>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>directive-code-svelte</key>
+      <dict>
+        <key>begin</key>
+        <string>(^|\G)(\s*)(\`{3,}|~{3,})\s*\{(code|code-block|code-cell)\}\s*(?i:(svelte)((\s+|:|\{)[^\`~]*)?$)</string>
+        <key>name</key>
+        <string>markup.directive.code.myst</string>
+        <key>end</key>
+        <string>(^|\G)(\2|\s{0,3})(\3)\s*$</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.myst</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.directive.myst</string>
+          </dict>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>support.variable.language.myst</string>
+          </dict>
+        </dict>
+        <key>endCaptures</key>
+        <dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.myst</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>begin</key>
+            <string>(^|\G)(\s*)(.*)</string>
+            <key>while</key>
+            <string>(^|\G)(?!\s*([\`~]{3,})\s*$)</string>
+            <key>contentName</key>
+            <string>meta.embedded.block.svelte</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>begin</key>
+                <string>(^|\G)(-{3})\s*$</string>
+                <key>beginCaptures</key>
+                <dict>
+                  <key>1</key>
+                  <dict>
+                    <key>name</key>
+                    <string>punctuation.options.myst</string>
+                  </dict>
+                </dict>
+                <key>end</key>
+                <string>(^|\G)(-{3})\s*$</string>
+                <key>endCaptures</key>
+                <dict>
+                  <key>2</key>
+                  <dict>
+                    <key>name</key>
+                    <string>punctuation.options.myst</string>
+                  </dict>
+                </dict>
+                <key>contentName</key>
+                <string>meta.embedded.block.options</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>source.yaml</string>
+                  </dict>
+                </array>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>source.svelte</string>
               </dict>
             </array>
           </dict>

--- a/template/languages.yaml
+++ b/template/languages.yaml
@@ -397,6 +397,13 @@
   sources:
     - source.shell
 - identifiers:
+    - svelte
+  language: svelte
+  name: svelte
+  sources:
+    - source.svelte
+  allow_yaml: true
+- identifiers:
     - typescript
     - ts
   language: typescript


### PR DESCRIPTION
Currently the syntax highlighting isn't quite right, probably
related to a bug in the underlying Svelte highlighter for vscode:

https://github.com/sveltejs/language-tools/issues/1094

I'd like to fix the above issue before asking this to be merged, but
I thought I'd file this initial PR for feedback.
