### PR TITLE
Add publishing step to OpenVSX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npm ci
-    - uses: lannonbr/vsce-action@master
+    - name: Publish to Open VSX Registry
+      uses: HaaLeo/publish-vscode-extension@v1
+      id: publishToOpenVSX
       with:
-        args: "publish -p $VSCE_TOKEN"
-      env:
-        VSCE_TOKEN: ${{ secrets.VSCE_PUB }}
+        pat: ${{ secrets.OPEN_VSX_TOKEN }}
+    - name: Publish to Visual Studio Marketplace
+      uses: HaaLeo/publish-vscode-extension@v1
+      with:
+        pat: ${{ secrets.VSCE_PUB }}
+        registryUrl: https://marketplace.visualstudio.com
+        extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}


### PR DESCRIPTION
This PR adds automatic publishing to the OpenVSX registry and therefore fixes #33. 

There are three more steps to take cc @chrisjsewell 
1. Add a repo secret for GitHub Actions called `OPEN_VSX_TOKEN` with a PAT obtained via following [this guide](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions) (steps 1-4)
2. After merging, try publishing for the first time 🚀
3. (Optional) claim the namespace by following [this doc](https://github.com/eclipse/openvsx/wiki/Namespace-Access#how-to-claim-a-namespace) so that the extension is verified on the registry.