### PR TITLE
Add more directives to syntax-highlight markdown in them

### DIFF
--- a/syntaxes/myst.tmLanguage
+++ b/syntaxes/myst.tmLanguage
@@ -125,7 +125,7 @@
         <key>comment</key>
         <string>These are directive blocks, whereby the content, should be treated as markdown</string>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\{(attention|caution|danger|error|important|hint|note|tip|warning)\}\s*(?=([^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\{(attention|caution|danger|error|important|hint|note|tip|warning|admonition|margin|toggle)\}\s*(?=([^`~]*)?$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>3</key>

--- a/syntaxes/myst.tmLanguage
+++ b/syntaxes/myst.tmLanguage
@@ -125,7 +125,7 @@
         <key>comment</key>
         <string>These are directive blocks, whereby the content, should be treated as markdown</string>
         <key>begin</key>
-        <string>(^|\G)(\s*)(`{3,}|~{3,})\{(attention|caution|danger|error|important|hint|note|tip|warning|admonition|margin|toggle)\}\s*(?=([^`~]*)?$)</string>
+        <string>(^|\G)(\s*)(`{3,}|~{3,})\{(attention|caution|danger|error|important|hint|note|tip|warning|admonition|margin|sidebar|toggle|dropdown|panels|epigraph|glossary|tabbed|div|figure)\}\s*(?=([^`~]*)?$)</string>
         <key>beginCaptures</key>
         <dict>
           <key>3</key>

--- a/template/directives.yaml
+++ b/template/directives.yaml
@@ -10,7 +10,15 @@ admonition_classes:
   - warning
   - admonition
   - margin
+  - sidebar
   - toggle
+  - dropdown
+  - panels
+  - epigraph
+  - glossary
+  - tabbed
+  - div
+  - figure
 code_classes:
   - code
   - code-block

--- a/template/directives.yaml
+++ b/template/directives.yaml
@@ -8,6 +8,9 @@ admonition_classes:
   - note
   - tip
   - warning
+  - admonition
+  - margin
+  - toggle
 code_classes:
   - code
   - code-block


### PR DESCRIPTION
See #44

Tested by running the edited extension locally and opening a myst markown file with some of these directives. The markdown inside indeed got syntax-highlighted nicely.