### PR TITLE
[FIX] ignore whitespace before directive after :::

### DIFF
--- a/src/mdPlugins.ts
+++ b/src/mdPlugins.ts
@@ -304,7 +304,7 @@ function colon_fence_rule(
   state.line = nextLine + (haveEndMarker ? 1 : 0)
 
   const token = state.push("fence", "code", 0)
-  token.info = params
+  token.info = params.trim()  // whitespace before a directive should be ignored
   token.content = state.getLines(startLine + 1, nextLine, len, true)
   token.markup = markup
   token.map = [startLine, state.line]


### PR DESCRIPTION
This change fixes directives with spaces between them and the colon fence:

    ::: {note}

Cf. https://myst-parser.readthedocs.io/en/stable/live-preview.html

![image](https://user-images.githubusercontent.com/7685034/222992605-30f8d9d6-13d2-44b8-a238-4cf08840132c.png)
